### PR TITLE
Change the CAPEC structure

### DIFF
--- a/sbin/db_mgmt_capec.py
+++ b/sbin/db_mgmt_capec.py
@@ -143,7 +143,7 @@ class CapecHandler(ContentHandler):
         if name == 'capec:CWE_ID':
             self.CWE_ID_tag = False
         if name == 'capec:Attack_Pattern':
-            self.capec.append({'name': self.name, 'id': self.id, 'summary': self.Summary, 'prerequisites': self.Attack_Prerequisite, 'solutions': self.Solution_or_Mitigation, 'related_weakness': self.Related_Weakness})
+            self.capec.append({'name': self.name, 'id': self.id, 'summary': '\n'.join(self.Summary), 'prerequisites': '\n'.join(self.Attack_Prerequisite), 'solutions': '\n'.join(self.Solution_or_Mitigation), 'related_weakness': self.Related_Weakness})
             self.Summary = []
             self.Attack_Prerequisite = []
             self.Solution_or_Mitigation = []


### PR DESCRIPTION
The summary, prerequisites and solutions were saved in array. This was useless, a simple text field is more convenient.
